### PR TITLE
Fix Ngraph analysis to digest full string

### DIFF
--- a/code/cipher.py
+++ b/code/cipher.py
@@ -297,7 +297,7 @@ class Ngraph(Distribution):
     def analyze(self, text):
         n = self.n
         self.result = {} # results are stored as a dictionary
-        for i in range( len(text) - n - 1 ):
+        for i in range( len(text) - n + 1 ):
             nary = text[ i:i+n ]
             if nary in self.result:
                 self.result[nary] += 1


### PR DESCRIPTION
Beforehand, the NGraph analysis method was not fully digesting the entire string.

---
I.E.  in the event the string is `"hello"` and `n = 3` it would only result in the following pair: `["hel"]`.  With this update, it will result in the following pairs: `["hel": 1, "llo": 1, "ell": 1]`


Sorry about the poor auto-generated branch name.  I wasn't sure how to checkout only this part of the repo without checking out all the presentations... 